### PR TITLE
support --vmnet-gateway=IP, e.g., 192.168.105.1 + drop support for macOS 10.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Install
 
+Requires macOS 10.15 or later.
+
 ```console
 brew install vde
 
@@ -57,8 +59,6 @@ The following additional files will be installed:
 - `/Library/LaunchDaemons/io.github.AkihiroSuda.vde_vmnet.bridged.en0.plist`
 
 Use `/var/run/vde.bridged.en0.ctl` as the VDE socket path.
-
-Needs macOS 10.15 or later.
 
 ## Advanced usage
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,9 @@ The following files will be installed:
 - `/usr/local/bin/vde_vmnet`
 - `/Library/LaunchDaemons/io.github.virtualsquare.vde-2.vde_switch.plist`
 - `/Library/LaunchDaemons/io.github.AkihiroSuda.vde_vmnet.plist`
+  - Configured to use `192.168.105.0/24`. Modifiy the file if it conflicts with your local network.
 
 See ["Testing without launchd"](#testing-without-launchd) if you don't prefer to use launchd.
-
-
-:warning: Known to conflict with VMware Fusion. See issue [#7](https://github.com/AkihiroSuda/vde_vmnet/issues/7).
 
 ## Usage
 
@@ -75,7 +73,7 @@ vde_switch --unix /tmp/vde.ctl
 ```
 
 ```console
-sudo vde_vmnet /tmp/vde.ctl
+sudo vde_vmnet --vmnet-gateway=192.168.105.1 /tmp/vde.ctl
 ```
 
 Note: make sure to run `vde_vmnet` with root (`sudo`). See [FAQs](#FAQs) for the reason.
@@ -125,14 +123,14 @@ On the other hand, `vde_vmnet` does not require the entire QEMU process to run a
 
 - Decide a unique MAC address for the VM, e.g. `de:ad:be:ef:00:01`.
 
-- Decide a static IP address, e.g., "192.168.60.100"
+- Decide a static IP address, e.g., "192.168.105.100"
 
 - Create `/etc/bootptab` like this. Make sure not to drop the "%%" header.
 ```
 # bootptab
 %%
 # hostname      hwtype  hwaddr              ipaddr          bootfile
-tmp-vm01        1       de:ad:be:ef:00:01   192.168.60.100
+tmp-vm01        1       de:ad:be:ef:00:01   192.168.105.100
 ```
 
 - Reload the DHCP daemon.

--- a/cli.c
+++ b/cli.c
@@ -12,6 +12,10 @@
 #define VERSION "UNKNOWN"
 #endif
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101500
+#error "Requires macOS 10.15 or later"
+#endif
+
 static void print_usage(const char *argv0) {
   printf("Usage: %s [OPTION]... VDESWITCH\n", argv0);
   printf("vmnet.framework support for rootless QEMU.\n");
@@ -66,13 +70,7 @@ struct cli_options *cli_options_parse(int argc, char *argv[]) {
       } else if (strcmp(optarg, "shared") == 0) {
         res->vmnet_mode = VMNET_SHARED_MODE;
       } else if (strcmp(optarg, "bridged") == 0) {
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
         res->vmnet_mode = VMNET_BRIDGED_MODE;
-#else
-        fprintf(stderr,
-                "vmnet mode \"bridged\" requires macOS 10.15 or later\n");
-        goto error;
-#endif
       } else {
         fprintf(stderr, "Unknown vmnet mode \"%s\"\n", optarg);
         goto error;
@@ -102,14 +100,12 @@ struct cli_options *cli_options_parse(int argc, char *argv[]) {
     goto error;
   }
   res->vde_switch = strdup(argv[optind]);
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 101500
   if (res->vmnet_mode == VMNET_BRIDGED_MODE && res->vmnet_interface == NULL) {
     fprintf(
         stderr,
         "vmnet mode \"bridged\" require --vmnet-interface to be specified\n");
     goto error;
   }
-#endif
   return res;
 error:
   print_usage(argv[0]);

--- a/cli.h
+++ b/cli.h
@@ -4,10 +4,16 @@
 #include <vmnet/vmnet.h>
 
 struct cli_options {
-  char *vde_group;              // --vde-group
-  operating_modes_t vmnet_mode; // --vmnet-mode
-  char *vmnet_interface;        // --vmnet-interface
-  char *vde_switch;             // arg
+  // --vde-group
+  char *vde_group;
+  // --vmnet-mode, corresponds to vmnet_operation_mode_key
+  operating_modes_t vmnet_mode;
+  // --vmnet-interface, corresponds to vmnet_shared_interface_name_key
+  char *vmnet_interface;
+  // --vmnet-gateway, corresponds to vmnet_start_address_key
+  char *vmnet_gateway;
+  // arg
+  char *vde_switch;
 };
 
 struct cli_options *cli_options_parse(int argc, char *argv[]);

--- a/launchd/io.github.AkihiroSuda.vde_vmnet.plist
+++ b/launchd/io.github.AkihiroSuda.vde_vmnet.plist
@@ -9,6 +9,7 @@
 		<key>ProgramArguments</key>
 		<array>
 			<string>/usr/local/bin/vde_vmnet</string>
+			<string>--vmnet-gateway=192.168.105.1</string>
 			<string>/var/run/vde.ctl</string>
 		</array>
 		<key>StandardErrorPath</key>

--- a/main.c
+++ b/main.c
@@ -9,6 +9,10 @@
 
 #include "cli.h"
 
+#if __MAC_OS_X_VERSION_MAX_ALLOWED < 101500
+#error "Requires macOS 10.15 or later"
+#endif
+
 static bool debug = false;
 
 #define DEBUGF(fmt, ...)                                                       \

--- a/test/test.ipxe
+++ b/test/test.ipxe
@@ -10,6 +10,12 @@ show netmask
 show dns
 show dhcp-server
 echo </vde_vmnet:iPXE-testing>
-# sleep for flushing the serial console
+
+echo [testing Internet connection]
+imgfetch http://google.com/
+
+echo [sleeping for flushing the serial console]
 sleep 1
+
+echo [exiting]
 reboot

--- a/test/test.sh
+++ b/test/test.sh
@@ -29,8 +29,13 @@ if ! grep -q "net0/mac:hex = 52:54:00:12:34:56" serial.log; then
 	exit 1
 fi
 
-if ! grep -q "net0.dhcp/ip:ipv4 = 192.168." serial.log; then
+if ! grep -q "net0.dhcp/ip:ipv4 = 192.168.105." serial.log; then
 	echo >&2 "ERROR: net0.dhcp/ip:ipv4 not found"
+	exit 1
+fi
+
+if ! grep -q "net0.dhcp/gateway:ipv4 = 192.168.105.1" serial.log; then
+	echo >&2 "ERROR: net0.dhcp/gateway:ipv4 not found"
 	exit 1
 fi
 


### PR DESCRIPTION
`vde_vmnet` binary itself does not have any default value,  but the launchd plist file is updated to use 192.168.105.1  as the default, so as to avoid conflicting with VMware Fusion.
    
Fix #7

Also drop support for macOS 10.14 and older.
