### PR TITLE
Discourage SETUID

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ However, signing a binary with `com.apple.vm.networking` entitlement seems to re
 
 https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_vm_networking
 
+### Is it possible to run `vde_vmnet` with SETUID?
+
+Discouraged, as it allows non-root users to write arbitrary files, by specifying certain CLI args and environment variables.
+
+Instead, consider using launchd or sudo.
+
+See [`./etc_sudoers.d/vde_vmnet`](./etc_sudoers.d/vde_vmnet) to allow running `sudo vde_vmnet` with reduced set of args and environment variables.
+
 ### How is vde_vmnet related to QEMU-builtin vmnet support?
 There are proposal to add builtin vmnet support for QEMU:
 - https://lore.kernel.org/qemu-devel/20210617143246.55336-1-yaroshchuk2000@gmail.com/

--- a/etc_sudoers.d/vde_vmnet
+++ b/etc_sudoers.d/vde_vmnet
@@ -1,0 +1,15 @@
+# make install: no
+
+# To allow non-root users to run `vde_vmnet`, use launchd OR install this file as `/etc/sudoers.d/vde_vmnet`.
+
+# Usage:
+# - sudo -u daemon -g staff /usr/local/bin/vde_switch ...
+# - sudo /usr/local/bin/vde_vmnet ...
+
+# Entries for shared mode (192.168.105.0/24)
+%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: /usr/local/bin/vde_switch --sock=/var/run/vde.ctl --pidfile=/var/run/vde.pid --group=staff --dirmode=0770
+%staff ALL=(root:root) NOPASSWD:NOSETENV: /usr/local/bin/vde_vmnet --vmnet-gateway=192.168.105.1 /var/run/vde.ctl
+
+# Entries for bridged mode (en0)
+%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: /usr/local/bin/vde_switch --sock=/var/run/vde.bridged.en0.ctl --pidfile=/var/run/vde.bridged.en0.pid --group=staff --dirmode=0770
+%staff ALL=(root:root) NOPASSWD:NOSETENV: /usr/local/bin/vde_vmnet --vmnet-mode=bridged --vmnet-interface=en0 /var/run/vde.bridged.en0.ctl

--- a/launchd/io.github.AkihiroSuda.vde_vmnet.bridged.en0.plist
+++ b/launchd/io.github.AkihiroSuda.vde_vmnet.bridged.en0.plist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- make install: no by default -->
 <plist version="1.0">
 	<dict>
 		<key>Label</key>

--- a/launchd/io.github.AkihiroSuda.vde_vmnet.plist
+++ b/launchd/io.github.AkihiroSuda.vde_vmnet.plist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- make install: yes -->
 <plist version="1.0">
 	<dict>
 		<key>Label</key>

--- a/launchd/io.github.virtualsquare.vde-2.vde_switch.bridged.en0.plist
+++ b/launchd/io.github.virtualsquare.vde-2.vde_switch.bridged.en0.plist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- make install: no by default -->
 <plist version="1.0">
 	<dict>
 		<!-- vde_switch itself is maintained at github.com/virtualsquare/vde-2 , but this plist file is maintained at github.com/AkihiroSuda/vde_vmnet -->

--- a/launchd/io.github.virtualsquare.vde-2.vde_switch.plist
+++ b/launchd/io.github.virtualsquare.vde-2.vde_switch.plist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- make install: yes -->
 <plist version="1.0">
 	<dict>
 		<!-- vde_switch itself is maintained at github.com/virtualsquare/vde-2 , but this plist file is maintained at github.com/AkihiroSuda/vde_vmnet -->

--- a/main.c
+++ b/main.c
@@ -267,6 +267,10 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "WARNING: Running without root. This is very unlikely to "
                     "work. See README.md .\n");
   }
+  if (geteuid() != getuid()) {
+    fprintf(stderr, "WARNING: Seems running with SETUID. This is insecure and "
+                    "highly discouraged. See README.md .\n");
+  }
   DEBUGF("Opening VDE \"%s\" (for UNIX group \"%s\")", cliopt->vde_switch,
          cliopt->vde_group);
   struct vde_open_args vdeargs = {


### PR DESCRIPTION
SETUID is discouraged, as it allows non-root users to write arbitrary files, by specifying certain CLI args and environment variables.

Instead, consider using launchd or sudo.

See `./etc_sudoers.d/vde_vmnet` to allow running `sudo vde_vmnet` with reduced set of args and environment variables.
