### PR TITLE
docs: update sudoers example to specify sha224 digests

### DIFF
--- a/etc_sudoers.d/README.md
+++ b/etc_sudoers.d/README.md
@@ -1,0 +1,7 @@
+# Example sudoers file for running `vde_vmnet`
+
+To allow non-root users to run `vde_vmnet`, use [launchd](../launchd) *or*
+install [the `vde_vmnet` file in this directory](./vde_vmnet) as `/etc/sudoers.d/vde_vmnet`.
+
+At least you have to modify the `sha224` digests in [`/etc/sudoers.d/vde_vmnet`](./vde_vmnet).
+See the comment lines in the file for the further information.

--- a/etc_sudoers.d/vde_vmnet
+++ b/etc_sudoers.d/vde_vmnet
@@ -2,14 +2,18 @@
 
 # To allow non-root users to run `vde_vmnet`, use launchd OR install this file as `/etc/sudoers.d/vde_vmnet`.
 
+# Prerequisite: Replace dummy sha224 digest values in this file with the actual sha224 digest values.
+#  - `openssl dgst -binary -sha224 /usr/local/bin/vde_switch | openssl base64`
+#  - `openssl dgst -binary -sha224 /usr/local/bin/vde_vmnet | openssl base64`
+
 # Usage:
 # - sudo -u daemon -g staff /usr/local/bin/vde_switch ...
 # - sudo /usr/local/bin/vde_vmnet ...
 
 # Entries for shared mode (192.168.105.0/24)
-%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: /usr/local/bin/vde_switch --sock=/var/run/vde.ctl --pidfile=/var/run/vde.pid --group=staff --dirmode=0770
-%staff ALL=(root:root) NOPASSWD:NOSETENV: /usr/local/bin/vde_vmnet --vmnet-gateway=192.168.105.1 /var/run/vde.ctl
+%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: sha224:N9Msbbq+1xHLHUYgtkCQ/vDvY6sWpKUdZoJZ5g== /usr/local/bin/vde_switch --sock=/var/run/vde.ctl --pidfile=/var/run/vde.pid --group=staff --dirmode=0770
+%staff ALL=(root:root) NOPASSWD:NOSETENV: sha224:XQMHsLqtLONKq3yskqPXLFfKli/60d02UALUXg== /usr/local/bin/vde_vmnet --vmnet-gateway=192.168.105.1 /var/run/vde.ctl
 
 # Entries for bridged mode (en0)
-%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: /usr/local/bin/vde_switch --sock=/var/run/vde.bridged.en0.ctl --pidfile=/var/run/vde.bridged.en0.pid --group=staff --dirmode=0770
-%staff ALL=(root:root) NOPASSWD:NOSETENV: /usr/local/bin/vde_vmnet --vmnet-mode=bridged --vmnet-interface=en0 /var/run/vde.bridged.en0.ctl
+%staff ALL=(daemon:staff) NOPASSWD:NOSETENV: sha224:N9Msbbq+1xHLHUYgtkCQ/vDvY6sWpKUdZoJZ5g== /usr/local/bin/vde_switch --sock=/var/run/vde.bridged.en0.ctl --pidfile=/var/run/vde.bridged.en0.pid --group=staff --dirmode=0770
+%staff ALL=(root:root) NOPASSWD:NOSETENV: sha224:XQMHsLqtLONKq3yskqPXLFfKli/60d02UALUXg== /usr/local/bin/vde_vmnet --vmnet-mode=bridged --vmnet-interface=en0 /var/run/vde.bridged.en0.ctl


### PR DESCRIPTION
Specifying digests is necessary when non-root users are allowed to
write files in `/usr/local/bin`.

Fix #18

Thanks to @jandubois for pointing out.
