### PR TITLE
Add --pidfile option to vde_vmnet

### DIFF
--- a/cli.c
+++ b/cli.c
@@ -47,6 +47,7 @@ static void print_usage(const char *argv0) {
          "specified\n");
   printf("--vmnet-interface-id=UUID           vmnet interface ID (default: "
          "random)\n");
+  printf("-p, --pidfile=PIDFILE               save pid to PIDFILE\n");
   printf("-h, --help                          display this help and exit\n");
   printf("-v, --version                       display version information and "
          "exit\n");
@@ -81,12 +82,13 @@ struct cli_options *cli_options_parse(int argc, char *argv[]) {
       {"vmnet-mask", required_argument, NULL, CLI_OPTIONS_ID_VMNET_MASK},
       {"vmnet-interface-id", required_argument, NULL,
        CLI_OPTIONS_ID_VMNET_INTERFACE_ID},
+      {"pidfile", required_argument, NULL, 'p'},
       {"help", no_argument, NULL, 'h'},
       {"version", no_argument, NULL, 'v'},
       {0, 0, 0, 0},
   };
   int opt = 0;
-  while ((opt = getopt_long(argc, argv, "hv", longopts, NULL)) != -1) {
+  while ((opt = getopt_long(argc, argv, "hvp", longopts, NULL)) != -1) {
     switch (opt) {
     case CLI_OPTIONS_ID_VDE_GROUP:
       res->vde_group = strdup(optarg);
@@ -120,6 +122,9 @@ struct cli_options *cli_options_parse(int argc, char *argv[]) {
         fprintf(stderr, "Failed to parse UUID \"%s\"\n", optarg);
         goto error;
       }
+      break;
+    case 'p':
+      res->pidfile = strdup(optarg);
       break;
     case 'h':
       print_usage(argv[0]);
@@ -233,5 +238,7 @@ void cli_options_destroy(struct cli_options *x) {
     free(x->vmnet_dhcp_end);
   if (x->vmnet_mask != NULL)
     free(x->vmnet_mask);
+  if (x->pidfile != NULL)
+    free(x->pidfile);
   free(x);
 }

--- a/cli.h
+++ b/cli.h
@@ -20,6 +20,8 @@ struct cli_options {
   char *vmnet_mask;
   // --vmnet-interface-id, corresponds to vmnet_interface_id_key
   uuid_t vmnet_interface_id;
+  // -p, --pidfile; writes pidfile using permissions of vde_vmnet
+  char *pidfile;
   // arg
   char *vde_switch;
 };

--- a/main.c
+++ b/main.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/uio.h>
@@ -215,6 +216,12 @@ static interface_ref start(VDECONN *vdeconn, struct cli_options *cliopt) {
   return iface;
 }
 
+static sigjmp_buf jmpbuf;
+static void signalhandler(int signal) {
+  printf("\nReceived signal %d\n", signal);
+  siglongjmp(jmpbuf, 1);
+}
+
 static void stop(interface_ref iface) {
   if (iface == NULL) {
     return;
@@ -249,6 +256,14 @@ int main(int argc, char *argv[]) {
     fprintf(stderr, "WARNING: Seems running with SETUID. This is insecure and "
                     "highly discouraged. See README.md .\n");
   }
+
+  if (sigsetjmp(jmpbuf, 1) != 0) {
+    goto done;
+  }
+  signal(SIGHUP, signalhandler);
+  signal(SIGINT, signalhandler);
+  signal(SIGTERM, signalhandler);
+
   int pid_fd = -1;
   if (cliopt->pidfile != NULL) {
     pid_fd = open(cliopt->pidfile, O_WRONLY | O_CREAT | O_EXLOCK | O_TRUNC | O_NONBLOCK, 0644);


### PR DESCRIPTION
That way the pidfile will be owned by the user running the daemon, and we can safely add e.g. `pkill -f /var/run/vde_vmnet.pid` to the sudoers file.

Also adds a signal handler for SIGHUB, SIGINT, and SIGTERM.