### PR TITLE
Bump vde-2 to include ENOBUFS fix for vde_switch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
         run: |
           git clone https://github.com/virtualsquare/vde-2.git /tmp/vde-2
           cd /tmp/vde-2
-          # Sep 8, 2021
-          git checkout 14e1c9e06f4dbdddc6fe4e85fc72a1d583b049ad
+          # Dec 12, 2021
+          git checkout 74278b9b7cf816f0356181f387012fdeb6d65b52
           autoreconf -fis
           ./configure --prefix=/opt/vde
           make

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Requires macOS 10.15 or later.
 
 ### Step 1: Install vde-2 (`vde_switch`)
 
-The version of `vde-2` must be [commit 50964c3f](https://github.com/virtualsquare/vde-2/tree/50964c3f) (2021-08-31) or later.
+The version of `vde-2` must be [commit 74278b9b](https://github.com/virtualsquare/vde-2/tree/74278b9b) (2021-12-12) or later.
 
 The `--prefix` dir below does not necessarily need to be `/opt/vde`, however, it is highly recommended
 to set the prefix to a directory that can be only written by the root.


### PR DESCRIPTION
Includes https://github.com/virtualsquare/vde-2/pull/35