### PR TITLE
Cross-compilation settings for arm-apple-darwin ("M1 Macs")

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,47 @@ jobs:
           ifconfig
       - name: Install build dependencies of VDE
         run: brew install autoconf automake
-      - name: Install VDE
+      - name: Make and Install VDE
         run: |
           git clone https://github.com/virtualsquare/vde-2.git /tmp/vde-2
           cd /tmp/vde-2
           # Dec 12, 2021
           git checkout 74278b9b7cf816f0356181f387012fdeb6d65b52
           autoreconf -fis
+          # compile for x86_64
           ./configure --prefix=/opt/vde
-          make
-          sudo make install
-      - name: Make
-        run: make PREFIX=/opt/vde
-      - name: Install
-        run: sudo make PREFIX=/opt/vde install
+          make PREFIX=/opt/vde
+          sudo make PREFIX=/opt/vde install
+          # cleanup
+          make distclean
+          # cross-compile for arm64
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          export CC=$(xcrun --sdk macosx --find clang)
+          export CXX=$(xcrun --sdk macosx --find clang++)
+          export CFLAGS="-arch arm64e -isysroot $SDKROOT -Wno-error=implicit-function-declaration"
+          export CXXFLAGS=$CFLAGS
+          ./configure --prefix=/opt/vde.arm64 --host=arm-apple-darwin --target=arm-apple-darwin --build=x86_64-apple-darwin
+          make PREFIX=/opt/vde.arm64
+          sudo make PREFIX=/opt/vde.arm64 install
+          unset SDKROOT CC CXX CFLAGS CXXFLAGS
+      - name: Make and Install vde_vmnet (x86_64)
+        run: |
+          git clone https://github.com/lima-vm/vde_vmnet.git /tmp/vde_vmnet
+          cd /tmp/vde_vmnet
+          make PREFIX=/opt/vde
+          sudo make PREFIX=/opt/vde install
+      - name: Cleanup
+        run: |
+          make clean
+      - name: Make and Install vde_vmnet (arm64)
+        run: |
+          export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)
+          export CC=$(xcrun --sdk macosx --find clang)
+          export CXX=$(xcrun --sdk macosx --find clang++)
+          export CFLAGS="-arch arm64e -isysroot $SDKROOT -Wno-error=implicit-function-declaration"
+          export CXXFLAGS=$CFLAGS
+          make PREFIX=/opt/vde.arm64
+          sudo make PREFIX=/opt/vde.arm64 install
       - name: Print launchd status (shared mode)
         run: launchctl print system/io.github.lima-vm.vde_vmnet.plist
       - name: Install test dependencies


### PR DESCRIPTION
This patch enables cross-compilation of `vde_vmnet` along with `vde_switch` for arm64-apple-darwin (so-called "M1 Macs") on x86_64-apple-darwin (so-called "Intel Macs").

--------------------------

At least on my environment, working steps to cross-compile are as follows:

1. (optional? not clear) Install Xcode (not Xcode Command Line Tools)
2.  `git clone https://github.com/virtualsquare/vde-2.git`
3. `cd vde-2`
4. `export SDKROOT=$(xcrun --sdk macosx --show-sdk-path)`
5. `export CC=$(xcrun --sdk macosx --find clang)`
6. `export CXX=$(xcrun --sdk macosx --find clang++)`
7. `export CFLAGS="-arch arm64e -isysroot $SDKROOT -Wno-error=implicit-function-declaration"`
8. `export CXXFLAGS=$CFLAGS`
9. `./configure --prefix=/opt/vde --host=arm-apple-darwin --target=arm-apple-darwin --build=x86_64-apple-darwin`
10. `make -j3 V=1`
11. `sudo make install PREFIX=/opt/vde`
12. `git clone https://github.com/lima-vm/vde_vmnet`
13. `cd vde_vmnet`
14. `make -j3 PREFIX=/opt/vde`
15. `sudo make PREFIX=/opt/vde install`
16. Done.

--------------------------
Logs:

```fish
reishoku@Jasmine ~/D/v/vde_vmnet (master)> uname -a
Darwin Jasmine.local 21.1.0 Darwin Kernel Version 21.1.0: Wed Oct 13 17:33:23 PDT 2021; root:xnu-8019.41.5~1/RELEASE_X86_64 x86_64
```

```fish
reishoku@Jasmine ~/D/v/vde_vmnet (master)> file /opt/vde/bin/*
/opt/vde/bin/dpipe:        Mach-O 64-bit executable arm64e
/opt/vde/bin/unixcmd:      Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_autolink: Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_over_ns:  Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_pcapplug: Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_plug:     Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_plug2tap: Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_router:   Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_switch:   Mach-O 64-bit executable arm64e
/opt/vde/bin/vde_vmnet:    Mach-O 64-bit executable arm64e
/opt/vde/bin/vdecmd:       Mach-O 64-bit executable arm64e
/opt/vde/bin/vdeterm:      Mach-O 64-bit executable arm64e
/opt/vde/bin/wirefilter:   Mach-O 64-bit executable arm64e
```